### PR TITLE
Use `stable` Rust Toolchain to build

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+stable


### PR DESCRIPTION
I'm not a rust dev, but when I try to build this repo, I get an error with building RocksDB:

```shell
$ cargo build 
<snip>
error: expected one of `!` or `::`, found keyword `static`
 --> /builder/penumbra-lcd/target/release/build/librocksdb-sys-792358183b62da9d/out/bindings.rs:3:11
  |
3 | rewriting static
  |           ^^^^^^ expected one of `!` or `::`

error: could not compile `librocksdb-sys` (lib) due to 1 previous error
<snip>
```

This is on a clean checkout at head, and reproduces with `cargo build` and `cargo build --release`. This is on cargo 1.79.0.

```shell
$ cargo version
cargo 1.79.0 (ffa9cf99a 2024-06-03)
```

Changing to the stable toolchain has me building without errors. 

