### PR TITLE
Add a configurable bind address

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+stable

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use rocket::serde::json::{json, Value};
 use rocket::State;
 use clap::Parser;
 use futures::TryStreamExt;
+use std::net::IpAddr;
 
 use penumbra_proto::{
     core::app::v1::{
@@ -38,6 +39,9 @@ struct Args {
 
     #[arg(short, long, default_value_t = 8000)]
     port: i32,
+
+    #[arg(short, long, default_value_t = String::from("127.0.0.1"))]
+    bind: String,
 }
 
 #[get("/cosmos/staking/v1beta1/validators?<status>")]
@@ -45,7 +49,7 @@ async fn validators(status: Option<String>, args: &State<Args>) -> Value {
     let channel = Channel::from_shared(args.node.to_string())
         .unwrap()
         .tls_config(ClientTlsConfig::new())
-        .unwrap()
+       .unwrap()
         .connect()
         .await
         .unwrap();
@@ -235,8 +239,13 @@ async fn signing_info(identity_key: &str, args: &State<Args>) -> Value {
 fn rocket() -> _ {
     let args = Args::parse();
 
+    let ip_addr: IpAddr = args.bind.parse().expect("Invalid IP address format");
+
     rocket::build()
-        .configure(rocket::Config::figment().merge(("port", args.port)))
+        .configure(rocket::Config::figment()
+                   .merge(("port", args.port))
+                   .merge(("address", ip_addr))
+        )
         .manage(args)
         .mount(
             "/",


### PR DESCRIPTION
Sometimes it's nice to be able to query data off of the current machine (ex. across wireguard). This adds an optional arg to allow a different bind address, and defaults it to `127.0.0.1` for backwards compatibility.

We're running and using this in production with a custom bind address today. 