### PR TITLE
Refactor `votes` route to return 400 when a voter has not cast a vote

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+stable

--- a/src/main.rs
+++ b/src/main.rs
@@ -469,8 +469,9 @@ async fn get_vote(voter: &str, proposal_id: u64, args: &State<Args>) -> status::
               },
               Some(option) => {
                   let vote = match option.vote {
+                      4 => "VOTE_OPTION_NO_WITH_VETO",
                       3 => "VOTE_OPTION_NO",
-                      2 => "VOTE_OPTION_YES",
+                      2 => "VOTE_OPTION_ABSTAIN",
                       1 => "VOTE_OPTION_YES",
                       _ => "VOTE_OPTION_UNSPECIFIED"
                   };

--- a/src/main.rs
+++ b/src/main.rs
@@ -452,7 +452,7 @@ async fn get_vote(voter: &str, proposal_id: u64, args: &State<Args>) -> status::
 
   let response = match validator_vote {
       None => {
-          status::Custom(rocket::http::Status::NotFound, Json(json!({
+          status::Custom(rocket::http::Status::BadRequest, Json(json!({
               "code": 3,
               "message": format!("voter: {} not found for proposal: {}", voter, proposal_id),
               "details": []
@@ -461,7 +461,7 @@ async fn get_vote(voter: &str, proposal_id: u64, args: &State<Args>) -> status::
       Some(vote) => {
           match &vote.vote {
               None => {
-                  status::Custom(rocket::http::Status::NotFound, Json(json!({
+                  status::Custom(rocket::http::Status::BadRequest, Json(json!({
                       "code": 3,
                       "message": format!("voter: {} not found for proposal: {}", voter, proposal_id),
                       "details": []

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use rocket::serde::json::{json, Value};
 use rocket::State;
 use clap::Parser;
 use futures::TryStreamExt;
+use std::net::IpAddr;
 
 use penumbra_proto::{
     core::app::v1::{
@@ -38,6 +39,9 @@ struct Args {
 
     #[arg(short, long, default_value_t = 8000)]
     port: i32,
+
+    #[arg(short, long, default_value_t = String::from("127.0.0.1"))]
+    bind: String,
 }
 
 #[get("/cosmos/staking/v1beta1/validators?<status>")]
@@ -45,7 +49,7 @@ async fn validators(status: Option<String>, args: &State<Args>) -> Value {
     let channel = Channel::from_shared(args.node.to_string())
         .unwrap()
         .tls_config(ClientTlsConfig::new())
-        .unwrap()
+       .unwrap()
         .connect()
         .await
         .unwrap();
@@ -235,8 +239,13 @@ async fn signing_info(identity_key: &str, args: &State<Args>) -> Value {
 fn rocket() -> _ {
     let args = Args::parse();
 
+    let ip_addr: IpAddr = args.bind.parse().expect("Invalid IP address format");
+
     rocket::build()
-        .configure(rocket::Config::figment().merge(("port", args.port)))
+        .configure(rocket::Config::figment()
+                   .merge(("port", args.port))
+                   .merge(("address", ip_addr))
+        )
         .manage(args)
         .mount(
             "/",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,8 @@
 extern crate rocket;
 
 use penumbra_proto::util::tendermint_proxy::v1::SyncInfo;
-use rocket::serde::json::{json, Value};
+use rocket::response::status;
+use rocket::serde::json::{Json, json, Value};
 use rocket::State;
 use clap::Parser;
 use futures::TryStreamExt;
@@ -422,72 +423,84 @@ async fn proposals(args: &State<Args>) -> Value {
     })
 }
 
-#[get("/cosmos/gov/v1beta1/proposals/<proposal_id>/votes/<voter>")]
-async fn proposal_vote(proposal_id: u64, voter: &str, args: &State<Args>) -> Value {
-    let channel = Channel::from_shared(args.node.to_string())
-        .unwrap()
-        .tls_config(ClientTlsConfig::new())
-        .unwrap()
-        .connect()
-        .await
-        .unwrap();
 
-    let mut client = GovernanceQueryServiceClient::new(channel.clone());
-    let votes_data: Vec<ValidatorVotesResponse> = client
-        .validator_votes(ValidatorVotesRequest { proposal_id: proposal_id })
-        .await
-        .unwrap()
-        .into_inner()
-        .try_collect::<Vec<_>>()
-        .await
-        .unwrap();
+async fn get_vote(voter: &str, proposal_id: u64, args: &State<Args>) -> status::Custom<Json<Value>> {
+  let channel = Channel::from_shared(args.node.to_string())
+      .unwrap()
+      .tls_config(ClientTlsConfig::new())
+      .unwrap()
+      .connect()
+      .await
+      .unwrap();
 
-    let validator_vote = votes_data
-        .iter()
-        .find(|&vote| {
-            let identity: IdentityKey = vote.clone().identity_key.unwrap().try_into().unwrap();
-            identity.to_string() == voter
-        });
+  let mut client = GovernanceQueryServiceClient::new(channel.clone());
+  let votes_data: Vec<ValidatorVotesResponse> = client
+      .validator_votes(ValidatorVotesRequest { proposal_id: proposal_id })
+      .await
+      .unwrap()
+      .into_inner()
+      .try_collect::<Vec<_>>()
+      .await
+      .unwrap();
 
-    match validator_vote {
-        None => json!({
-            "code": 3,
-            "message": format!("voter: {} not found for proposal: {}", voter, proposal_id),
-            "details": []
-        }),
-        Some(vote) => {
-            match &vote.vote {
-                None => json!({
-                    "code": 3,
-                    "message": format!("voter: {} not found for proposal: {}", voter, proposal_id),
-                    "details": []
-                }),
-                Some(option) => {
-                    let vote = match option.vote {
-                        3 => "VOTE_OPTION_NO",
-                        2 => "VOTE_OPTION_YES",
-                        1 => "VOTE_OPTION_YES",
-                        _ => "VOTE_OPTION_UNSPECIFIED"
-                    };
+  let validator_vote = votes_data
+      .iter()
+      .find(|&vote| {
+          let identity: IdentityKey = vote.clone().identity_key.unwrap().try_into().unwrap();
+          identity.to_string() == voter
+      });
 
-                    json!({
-                        "vote": {
-                          "proposal_id": proposal_id.to_string(),
-                          "voter": voter,
-                          "option": vote,
-                          "options": [
-                            {
-                              "option": vote,
-                              "weight": "1.000000000000000000"
-                            }
-                          ]
-                        }
-                      })
-                }
-            }
-        }
-    }
+  let response = match validator_vote {
+      None => {
+          status::Custom(rocket::http::Status::NotFound, Json(json!({
+              "code": 3,
+              "message": format!("voter: {} not found for proposal: {}", voter, proposal_id),
+              "details": []
+          })))
+      },
+      Some(vote) => {
+          match &vote.vote {
+              None => {
+                  status::Custom(rocket::http::Status::NotFound, Json(json!({
+                      "code": 3,
+                      "message": format!("voter: {} not found for proposal: {}", voter, proposal_id),
+                      "details": []
+                  })))
+              },
+              Some(option) => {
+                  let vote = match option.vote {
+                      3 => "VOTE_OPTION_NO",
+                      2 => "VOTE_OPTION_YES",
+                      1 => "VOTE_OPTION_YES",
+                      _ => "VOTE_OPTION_UNSPECIFIED"
+                  };
+
+                  status::Custom(rocket::http::Status::Ok, Json(json!({
+                      "vote": {
+                        "proposal_id": proposal_id.to_string(),
+                        "voter": voter,
+                        "option": vote,
+                        "options": [
+                          {
+                            "option": vote,
+                            "weight": "1.000000000000000000"
+                          }
+                        ]
+                      }
+                  })))
+              }
+          }
+      }
+  };
+
+  response
 }
+
+#[get("/cosmos/gov/v1beta1/proposals/<proposal_id>/votes/<voter>")]
+async fn proposal_vote(proposal_id: u64, voter: &str, args: &State<Args>) -> status::Custom<Json<Value>> {
+    get_vote(voter, proposal_id, args).await
+}
+
 
 #[launch]
 fn rocket() -> _ {

--- a/src/main.rs
+++ b/src/main.rs
@@ -469,10 +469,9 @@ async fn get_vote(voter: &str, proposal_id: u64, args: &State<Args>) -> status::
               },
               Some(option) => {
                   let vote = match option.vote {
-                      4 => "VOTE_OPTION_NO_WITH_VETO",
                       3 => "VOTE_OPTION_NO",
-                      2 => "VOTE_OPTION_ABSTAIN",
-                      1 => "VOTE_OPTION_YES",
+                      2 => "VOTE_OPTION_YES",
+                      1 => "VOTE_OPTION_ABSTAIN",
                       _ => "VOTE_OPTION_UNSPECIFIED"
                   };
 


### PR DESCRIPTION
This is in line with behavior from the existing LCD API that ships in Cosmos SDK. 

I'm leaning fairly heavily on pattern matching and some help from ChatGPT to supplement my nascent rust knowledge, so there could be a better way. Feel free to drop this PR, or suggest changes if you know how to do this more elegantly.